### PR TITLE
Setup performance test

### DIFF
--- a/SCTF/PerformanceTest/PerformanceTest.vcxproj
+++ b/SCTF/PerformanceTest/PerformanceTest.vcxproj
@@ -104,10 +104,13 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\SFML-2.6.1\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\SFML-2.6.1\lib\sfml-main-d.lib;..\SFML-2.6.1\lib\sfml-system-d.lib;..\SFML-2.6.1\lib\sfml-window-d.lib;..\SFML-2.6.1\lib\sfml-graphics-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -118,12 +121,15 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\SFML-2.6.1\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\SFML-2.6.1\lib\sfml-main.lib;..\SFML-2.6.1\lib\sfml-system.lib;..\SFML-2.6.1\lib\sfml-window.lib;..\SFML-2.6.1\lib\sfml-graphics.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SCTF/PerformanceTest/main.cpp
+++ b/SCTF/PerformanceTest/main.cpp
@@ -14,7 +14,7 @@ int main()
 	game.LoadMap("../Game/map001");
 
 	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-	for (size_t i = 0; i < config.framerate * 12; i++)
+	for (size_t i = 0; i < config.framerate * 120; i++)
 	{
 		game.Update(1.f/config.framerate);
 	}

--- a/SCTF/PerformanceTest/main.cpp
+++ b/SCTF/PerformanceTest/main.cpp
@@ -1,4 +1,25 @@
+#include <iostream>
+#include <chrono>
+
+#include "../Game/Configuration.hpp"
+#include "../Game/Game.hpp"
+#include "../Game/Camera.hpp"
+
+
 int main()
 {
+	Configuration config{ 60,101,101,0.0 };
+	Game game{ config };
+
+	game.LoadMap("../Game/map001");
+
+	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+	for (size_t i = 0; i < config.framerate * 120; i++)
+	{
+		game.Update(1.f/config.framerate);
+	}
+	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+	std::cout << std::chrono::duration_cast<std::chrono::seconds>(end - begin).count() << " seconds" << std::endl;
+
 	return 0;
 }

--- a/SCTF/PerformanceTest/main.cpp
+++ b/SCTF/PerformanceTest/main.cpp
@@ -14,7 +14,7 @@ int main()
 	game.LoadMap("../Game/map001");
 
 	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-	for (size_t i = 0; i < config.framerate * 120; i++)
+	for (size_t i = 0; i < config.framerate * 12; i++)
 	{
 		game.Update(1.f/config.framerate);
 	}


### PR DESCRIPTION
Simple performance test, currently takes about 70-80 seconds to simulate 120 seconds of game time without rendering, both with 80x80 and 100x100 partitioning on map001.

Also fixing a minor threading bug that caused collision solver worker threads to hang.