### PR TITLE
Clean up threading in CollisionSolver

### DIFF
--- a/SCTF/Game/CollisionSolver.hpp
+++ b/SCTF/Game/CollisionSolver.hpp
@@ -1,21 +1,18 @@
 #pragma once
 
 #include <thread>
-#include <shared_mutex>
 #include <atomic>
-#include <chrono>
-#include <iostream>
 #include <barrier>
-#include <functional>
 
 #include "Particles.hpp"
 #include "Partitioner.hpp"
 
-using namespace std::chrono_literals;
 
-
-std::barrier phase1_barrier(5);
-std::barrier phase2_barrier(5);
+#define parallelism 8
+std::barrier phase1_start_barrier(parallelism + 1);
+std::barrier phase1_end_barrier(parallelism + 1);
+std::barrier phase2_start_barrier(parallelism + 1);
+std::barrier phase2_end_barrier(parallelism + 1);
 
 class CollisionSolver
 {
@@ -26,48 +23,46 @@ public:
 		partitioner{ partitioner },
 		running{ true }
 	{
-		std::vector<size_t> column_indices[8];
-		size_t columns_per_thread = partitioner.number_of_columns / 4;
+		std::vector<size_t> column_indices[2 * parallelism];
+		size_t columns_per_thread = partitioner.number_of_columns / parallelism;
 		for (size_t i = 0; i < columns_per_thread - 1; i++)
 		{
-			for (size_t j = 0; j < 4; j++)
+			for (size_t j = 0; j < parallelism; j++)
 			{
 				column_indices[j].push_back(j * columns_per_thread + i);
 			}
 		}
-		for (size_t j = 0; j < 4; j++)
+		for (size_t j = 0; j < parallelism; j++)
 		{
 			column_indices[4 + j].push_back((j + 1) * columns_per_thread - 1);
 		}
 
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns(column_indices[0], 0); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns(column_indices[1], 1); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns(column_indices[2], 2); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns(column_indices[3], 3); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns2(column_indices[4], 4); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns2(column_indices[5], 5); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns2(column_indices[6], 6); } });
-		worker_threads.emplace_back([this, column_indices]() { while (running) { UpdateColumns2(column_indices[7], 7); } });
+		for (size_t i = 0; i < parallelism; i++)
+		{
+			phase1_threads.emplace_back([this, column_indices, i]() { while (running) { UpdateColumns(column_indices[i], i); } });
+			phase2_threads.emplace_back([this, column_indices, i]() { while (running) { UpdateColumns(column_indices[parallelism + i], parallelism + i); } });
+		}
 	}
 
 	~CollisionSolver()
 	{
 		running = false;
-		phase1_barrier.arrive_and_wait();
-		phase2_barrier.arrive_and_wait();
-		for (size_t i = 0; i < num_threads; i++)
+		phase1_start_barrier.arrive_and_drop();
+		phase2_start_barrier.arrive_and_drop();
+		for (size_t i = 0; i < parallelism; i++)
 		{
-			worker_threads[i].join();
+			phase1_threads[i].join();
 		}
-		for (size_t i = 0; i < num_threads; i++)
+		for (size_t i = 0; i < parallelism; i++)
 		{
-			worker_threads[4 + i].join();
+			phase2_threads[i].join();
 		}
 	}
 
 	void UpdateColumns(const std::vector<size_t>& column_indices, size_t thread_id)
 	{
-		phase1_barrier.arrive_and_wait();
+		if (thread_id < parallelism) { phase1_start_barrier.arrive_and_wait(); }
+		else { phase2_start_barrier.arrive_and_wait(); }
 		if (!running) return;
 
 		for (size_t i: column_indices)
@@ -105,61 +100,18 @@ public:
 			}
 		}
 
-		phase1_barrier.arrive_and_wait();
-	}
-
-	//TODO: Code duplication.
-	void UpdateColumns2(const std::vector<size_t>& column_indices, size_t thread_id)
-	{
-		phase2_barrier.arrive_and_wait();
-		if (!running) return;
-
-		for (size_t i : column_indices)
-		{
-			for (size_t j = 0; j < partitioner.number_of_rows; j++)
-			{
-				if (partitioner.partitions[i][j].ids.size() >= 2)
-				{
-					for (size_t k = 0; k < partitioner.partitions[i][j].ids.size() - 1; k++)
-					{
-						for (size_t l = k + 1; l < partitioner.partitions[i][j].ids.size(); l++)
-						{
-							const auto id1 = partitioner.partitions[i][j].ids[k];
-							const auto id2 = partitioner.partitions[i][j].ids[l];
-							sf::Vector2f collision_vector = particles.current_position[id1] - particles.current_position[id2]; //TODO: Handle null collision vector.
-
-							if (collision_vector.x == 0 && collision_vector.y == 0)
-							{
-								continue;
-							}
-
-							float distance_squared = GetLengthSquared(collision_vector);
-							if (distance_squared < 1)
-							{
-								float distance = GetLengthForUnitOrShorter(collision_vector);
-								if (distance == 0) continue;
-								sf::Vector2f normalized_collision_vector = collision_vector / distance;
-								particles.current_position[id1] = particles.current_position[id1] + normalized_collision_vector * (1 - distance) / 2.0f;
-								particles.current_position[id2] = particles.current_position[id2] - normalized_collision_vector * (1 - distance) / 2.0f;
-							}
-						}
-					}
-				}
-				partitioner.partitions[i][j].ids.resize(0);
-			}
-		}
-
-		phase2_barrier.arrive_and_wait();
+		if (thread_id < parallelism) { phase1_end_barrier.arrive_and_wait(); }
+		else { phase2_end_barrier.arrive_and_wait(); }
 	}
 
 	void Update(float dt)
 	{
 		for (size_t i = 0; i < particles.GetNumberOfParticles(); i++) partitioner.MaybeInsertIntoPartition(i);
 
-		phase1_barrier.arrive_and_wait();
-		phase1_barrier.arrive_and_wait();
-		phase2_barrier.arrive_and_wait();
-		phase2_barrier.arrive_and_wait();
+		phase1_start_barrier.arrive_and_wait();
+		phase1_end_barrier.arrive_and_wait();
+		phase2_start_barrier.arrive_and_wait();
+		phase2_end_barrier.arrive_and_wait();
 	}
 
 	static void NoOp() noexcept {}
@@ -170,9 +122,7 @@ private:
 	Partitioner& partitioner;
 
 	//Threading stuff.
-	bool running;
-	const int num_threads = 4;
-	std::vector<std::thread> worker_threads;
-	std::atomic<size_t> threads_ready = 0;
-	std::atomic<size_t> threads_done = 0;
+	std::atomic<bool> running;
+	std::vector<std::thread> phase1_threads;
+	std::vector<std::thread> phase2_threads;
 };


### PR DESCRIPTION
Code duplication solved, unneeded members and includes removed, made it parameterizable, etc.

On my notebook with 4 physical cores using 8 threads seems to provide a marginal speedup, from 80 seconds to a stable 70 seconds. That is until I realized my notebook was in a low power state somehow, even though it was on the charger.

Running it with a somewhat charged battery the performance test only takes 40-44 seconds and the speedup seems to be smaller to non-existent.